### PR TITLE
chore: update badges, keywords, and merge publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jsonresume/public)
 [![matrix](https://img.shields.io/badge/matrix-join%20chat-%230dbd8b)](https://matrix.to/#/#json-resume:one.ems.host)
-[![build status](https://img.shields.io/github/workflow/status/jsonresume/resume-cli/Main)](https://github.com/jsonresume/resume-cli/actions)
-[![npm package](https://img.shields.io/npm/v/@jsonresume/jsonresume-theme-class)](https://www.npmjs.org/package/resume-cli)
+[![npm package](https://img.shields.io/npm/v/@jsonresume/jsonresume-theme-class)](https://www.npmjs.com/package/@jsonresume/jsonresume-theme-class)
 
 
 A modern theme for [JSON Resume](http://jsonresume.org/) which is self-contained. The content of the resume will work offline and can be hosted without depending on

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jsonresume/jsonresume-theme-class",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jsonresume/jsonresume-theme-class",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "handlebars": "^4.7.7",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@jsonresume/jsonresume-theme-class",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Class Theme for JSON Resume",
   "author": "James Spencer",
   "license": "MIT",
-	"private": false,
+  "private": false,
   "keywords": [
     "resume",
     "handlebars",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,18 @@
 {
   "name": "@jsonresume/jsonresume-theme-class",
   "version": "0.2.0",
-  "description": "Class theme for JSONResume.org",
+  "description": "Class Theme for JSON Resume",
   "author": "James Spencer",
   "license": "MIT",
 	"private": false,
+  "keywords": [
+    "resume",
+    "handlebars",
+    "cv",
+    "jsonresume",
+    "jsonresume-theme",
+    "jsonresume-theme-class"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/jsonresume/jsonresume-theme-class"


### PR DESCRIPTION
We'll now be able to publish a new version of the theme by creating a release on GitHub!