### PR TITLE
fix: render username even if no url specified

### DIFF
--- a/resume.handlebars
+++ b/resume.handlebars
@@ -74,17 +74,21 @@
           {{network}}
         </strong>
         {{/if}}
-        {{#if url}}
-        <div class="url">
+        <div>
+          {{#if url}}
           <a href="{{url}}">
-          {{#if username}}
-            {{username}}
-          {{else}}
-            {{url}}
-          {{/if}}
+            {{#if username}}
+              {{username}}
+            {{else}}
+              {{url}}
+            {{/if}}
           </a>
+          {{else}}
+          <span>
+            {{username}}
+          </span>
+          {{/if}}
         </div>
-        {{/if}}
       </div>
       {{/each}}
     </section>


### PR DESCRIPTION
When given a JSON Resume with the following, the theme would render an unappealing entry for that profile. This will allow use that username as-is without being linked.

```json
{
  "profiles": [
    {
      "network": "Twitter",
      "username": "neutralthoughts",
      "url": ""
    },
    {
      "network": "SoundCloud",
      "username": "dandymusicnl",
      "url": "https://soundcloud.com/dandymusicnl"
    }
  ]
}
```

### Before

![image](https://user-images.githubusercontent.com/22801583/180655687-30f82d5f-e0aa-4e85-9fee-63a0b13b9c7f.png)


### After

![image](https://user-images.githubusercontent.com/22801583/180655681-c6c4cae6-b729-46a9-ae7b-fb50a291ea0e.png)
