### PR TITLE
chores: fix description and viewport

### DIFF
--- a/resume.handlebars
+++ b/resume.handlebars
@@ -2,11 +2,11 @@
 <html>
   <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, user-scalable=no, minimal-ui">
+  <meta name="viewport" content="width=device-width, minimal-ui">
 
   {{#resume.basics}}
   <title>{{name}} - CV</title>
-  <meta name="description" name="{{summary}}">
+  <meta name="description" content="{{summary}}">
 
   <meta property="og:site_name" content="{{name}}">
   <meta property="og:title" content="{{label}}">


### PR DESCRIPTION
## user-scalable

When I forked this repository, I left `user-scalable=no`, but we don't actually need this and SEO tools complain about it.

> `[user-scalable="no"]` is used in the `<meta name="viewport">` element or the `[maximum-scale]` attribute is less than 5. 

## Description

When adding the `meta[name=description]` element, I accidentally set `name` twice instead of setting `content`.

This also led to SEO tools complaining, but was just a bug in general.

>  Document does not have a meta descriptionDescription text is empty.
