### PR TITLE
fix: white background for lightmode

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ article,aside,details,figcaption,figure,footer,header,hgroup,nav,section,summary
 
 body {
   --fg-color: black;
-  --bg-color: #F9F9F9;
+  --bg-color: #FFFFFF;
   --header-h1-fg-color: #FFFFFF;
   --header-h2-fg-color: #F3F3F3;
   --header-bg-color: #1866C3;


### PR DESCRIPTION
Changes the light mode background to #FFFFFF.

The motivation is that we need to support HTML and PDF, and PDF is probably the more important of the two. Unfortunately, the PDF looks ugly with a non-white background as the background only extends to the content/body, not the remainder of the last page.

Ideally, I should've been able to use a media query like:

```css
@media (print) {
  body {
    --bg-color: #FFFFFF;
  }
}
```

However, it seems the renderer doesn't use print media queries, so this was ignored. When or if this is supported, it'd be much better to change the background color back to `#F9F9F9` and put the media query back.

### Related

* https://github.com/jsonresume/jsonresume-theme-class/issues/22