### PR TITLE
fix: move from float to flex layout

### DIFF
--- a/resume.handlebars
+++ b/resume.handlebars
@@ -46,6 +46,7 @@
   <section id="basics">
     <div class="contact">
     <h3>Contact</h3>
+    <div class="split">
     {{#if url}}
     <div class="website">
       <strong>Website</strong>
@@ -70,6 +71,7 @@
     </div>
     {{/if}}
     </div>
+    </div>
     {{#if summary}}
     <div class="summary">
       <h3>About</h3>
@@ -77,7 +79,7 @@
     </div>
     {{/if}}
     {{#if profiles.length}}
-    <section id="profiles">
+    <section id="profiles" class="split">
       {{#each profiles}}
       <div class="item">
         {{#if network}}
@@ -122,6 +124,7 @@
       </h3>
       {{/if}}
 
+      <div class="split">
       {{#if position}}
       <div class="work_position">
         {{position}}
@@ -148,6 +151,7 @@
         <a href="{{website}}">{{website}}</a>
       </div>
       {{/if}}
+      </div>
 
       {{#if summary}}
       <div class="summary">
@@ -177,6 +181,7 @@
       </h3>
       {{/if}}
 
+      <div class="split">
       {{#if position}}
       <div class="work_position">
         {{position}}
@@ -203,6 +208,7 @@
         <a href="{{website}}">{{website}}</a>
       </div>
       {{/if}}
+      </div>
 
       {{#if summary}}
       <div class="summary">
@@ -227,6 +233,7 @@
     {{#each resume.education}}
     <div class="item">
 
+      <div class="split">
       {{#if institution}}
       <div class="institution">
         {{institution}}
@@ -249,6 +256,7 @@
         <a href="{{url}}">{{url}}</a>
       </div>
       {{/if}}
+      </div>
 
       {{#if qualification}}
       <div class="qualification">

--- a/style.css
+++ b/style.css
@@ -92,30 +92,27 @@ header h2 {
   border-bottom: 1px #E2E2E2 solid;
 }
 #basics h3 {
-  margin-top: 1.5em;
   margin-bottom: 10px;
-}
-#basics .contact strong {
-  line-height: 1.3;
-  float: left;
-  width: 80px;
 }
 
 .contact h3 {
   padding-bottom: 10px;
 }
 
+.split {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.split strong {
+  margin-right: 2em;
+}
+
 .website,
 .email,
 .phone {
   margin-bottom: 10px;
-  float: left;
   width: 50%;
-}
-
-.summary {
-  padding-top: 5px;
-  clear: both;
 }
 
 #profiles {
@@ -123,7 +120,6 @@ header h2 {
 }
 
 #profiles .item {
-  float: left;
   width: 50%;
 }
 
@@ -138,7 +134,6 @@ header h2 {
 .study_date,
 .qualification {
   margin-bottom: 10px;
-  float: left;
   width: 30%;
 }
 
@@ -183,7 +178,6 @@ header h2 {
 #languages .item,
 #interests .item,
 #skills .item {
-  float: left;
   width: 50%;
 }
 


### PR DESCRIPTION
### Switching from Float to Flex

In the original theme that we forked, it used the float layout. Turns out this has a major impact on parsing the PDF file as it changes the read order of text in the PDF.

This caused résumé parsers to struggle to detect information like names. Moving to `flex` resolves the issues.

### Reduced Padding/Margin

Also reduces the margin/padding under some elements by a small amount. The résumé was wasting a fair bit of space before.