### PR TITLE
fix: revert language logic and introduce meta lang

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .github/
 assets/
+test/
 .editorconfig

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ resume export --theme @jsonresume/jsonresume-theme-class your-name.pdf
 
 ### Notes
 
-* This theme expects languages in your résumé to be defined with language codes (i.e. `en`), not language names (i.e. `English`).
-* If languages are specified, ensure the first language is the language your résumé is written in, so that the document language is set correctly.
+* It's recommended to declare the `meta.language` property in your JSON Resume for accessibility. This is the [BCP47 tag](https://developer.mozilla.org/docs/Web/HTML/Global_attributes/lang#language_tag_syntax) for the language your your résumé is written in. For example, `en` for English.
 
 ## Features
 

--- a/index.js
+++ b/index.js
@@ -111,19 +111,6 @@ function render(resume) {
     }
   }
 
-  const primaryLanguage = resume.languages && resume.languages[0].language;
-
-  if (primaryLanguage) {
-    Handlebars.registerHelper("lang", (body) => {
-      const languageNames = new Intl.DisplayNames([primaryLanguage], {
-        type: 'language',
-
-      });
-
-      return languageNames.of(body);
-    });
-  }
-
   const html = Handlebars.compile(template)({
     css,
     resume

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jsonresume/jsonresume-theme-class",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jsonresume/jsonresume-theme-class",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "handlebars": "^4.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonresume/jsonresume-theme-class",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Class Theme for JSON Resume",
   "author": "Seth Falco",
   "license": "MIT",

--- a/resume.handlebars
+++ b/resume.handlebars
@@ -1,40 +1,44 @@
 <!DOCTYPE html>
-{{#if resume.languages.0.language}}
-<html lang="{{resume.languages.0.language}}">
+{{#if resume.meta.language}}
+<html lang="{{resume.meta.language}}">
 {{else}}
 <html>
 {{/if}}
   <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary">
+    {{#if resume.basics.name}}
+    <title>{{resume.basics.name}} - CV</title>
+    <meta property="og:site_name" content="{{resume.basics.name}}">
+    {{else}}
+    <title>CV</title>
+    {{/if}}
 
-  {{#resume.basics}}
-  <title>{{name}} - CV</title>
-  <meta name="description" content="{{summary}}">
+    {{#if resume.basics.summary}}
+    <meta name="description" content="{{resume.basics.summary}}">
+    <meta property="og:description" content="{{resume.basics.summary}}">
+    {{/if}}
 
-  <meta property="og:site_name" content="{{name}}">
-  <meta property="og:title" content="{{label}}">
-  <meta property="og:description" content="{{summary}}">
+    {{#if resume.basics.label}}
+    <meta property="og:title" content="{{resume.basics.label}}">
+    {{/if}}
 
-  {{#if image}}
-  <link rel="icon" href="{{image}}">
-  <meta property="og:image" content="{{image}}">
-  <meta property="og:image:alt" content="Avatar of {{name}}.">
-  {{/if}}
-  {{/resume.basics}}
+    {{#if resume.basics.image}}
+    <meta property="og:image" content="{{resume.basics.image}}">
+    <link rel="icon" href="{{resume.basics.image}}">
+    {{#if resume.basics.name}}
+    <meta property="og:image:alt" content="Avatar of {{resume.basics.name}}.">
+    {{/if}}
+    {{/if}}
 
-  {{#resume.custom}}
-  {{#if xTwitterHandle}}
-  <meta name="twitter:site" content="{{xTwitterHandle}}">
-  {{/if}}
-  {{/resume.custom}}
+    {{#if resume.custom.xTwitterHandle}}
+    <meta name="twitter:site" content="{{resume.custom.xTwitterHandle}}">
+    {{/if}}
 
-  <style>
-  {{{css}}}
-  </style>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="twitter:card" content="summary">
+    <meta property="og:type" content="website">
 
+    <style>{{{css}}}</style>
   </head>
   <body>
 
@@ -313,9 +317,7 @@
     {{#each resume.languages}}
     <div class="item">
       {{#if language}}
-      <div>
-        {{lang language}}
-      </div>
+      <div>{{language}}</div>
       {{/if}}
       {{#if fluency}}
       <div class="level">

--- a/test/fixture.resume.json
+++ b/test/fixture.resume.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json",
+  "meta": {
+    "language": "en"
+  },
   "basics": {
     "name": "Seth Falco",
     "label": "Open-Sourcerer 🧙‍♂️",
@@ -76,11 +79,11 @@
   ],
   "languages": [
     {
-      "language": "en",
+      "language": "English",
       "fluency": "Native"
     },
     {
-      "language": "fr",
+      "language": "French",
       "fluency": "Elementary"
     }
   ]


### PR DESCRIPTION
Partly reverts one of the changes made in https://github.com/jsonresume/jsonresume-theme-class/pull/48 which makes a change that doesn't completely adhere to the JSON Resume spec.

The JSON Resume spec expects languages to be defined using a natural language name, not a language code. Using this properly differently is expected and ultimately makes this incompatible with other themes which defeats the point of the standard.

Instead, we'll use a custom property in `meta` that users can choose to use.

Does the following:

* Reads `meta.language` to set the document language.
* Makes the `<head>` section of the template _a lot_ more defensive, as every field is optional.