### PR TITLE
feat: added project section to template

### DIFF
--- a/resume.handlebars
+++ b/resume.handlebars
@@ -216,6 +216,56 @@
     </section>
     {{/if}}
 
+    {{#if resume.projects.length}}
+    <section id="projects">
+      <h2>Projects</h2>
+      {{#each resume.projects}}
+      <div class="item">
+        {{#if name}}
+        <h3 class="project_name">
+          {{#if url}}
+          <a href="{{url}}" target="_blank"
+            rel="noopener noreferrer">{{name}}</a>
+          {{else}}
+          {{name}}
+          {{/if}}
+        </h3>
+        {{/if}}
+
+        <div class="split">
+          {{#if entity}}
+          <div class="project_entity">
+            {{entity}}
+          </div>
+          {{/if}}
+          <div class="project_date">
+            {{#if startDate}}
+            {{#if endDate}}
+            {{{date startDate}}} - {{{date endDate}}}
+            {{else}}
+            {{{date startDate}}}
+            {{/if}}
+            {{/if}}
+          </div>
+        </div>
+
+        {{#if description}}
+        <div class="summary">
+          <p>{{{markdown description}}}</p>
+        </div>
+        {{/if}}
+        {{#if highlights.length}}
+        <ul class="highlights">
+          {{#each highlights}}
+          <li>{{{markdown .}}}</li>
+          {{/each}}
+        </ul>
+        {{/if}}
+      </div>
+      {{/each}}
+    </section>
+    {{/if}}
+
     {{#if resume.education.length}}
     <section id="education">
       <h2>Education</h2>

--- a/style.css
+++ b/style.css
@@ -82,6 +82,13 @@ header h2 {
   margin-right: 2em;
 }
 
+.project_entity,
+.project_date,
+.project_website {
+  margin-bottom: 10px;
+  width: 30%;
+}
+
 .website,
 .email,
 .phone,
@@ -117,13 +124,15 @@ header h2 {
 }
 
 #work,
-#volunteer {
+#volunteer,
+#projects {
   padding-bottom: 5px;
   border-bottom: 1px var(--separator-color) solid;
 }
 
 #work .item,
-#volunteer .item {
+#volunteer .item,
+#projects .item {
   margin: 25px 0;
 }
 

--- a/test/fixture.resume.json
+++ b/test/fixture.resume.json
@@ -54,6 +54,19 @@
       ]
     }
   ],
+  "projects": [
+    {
+      "name": "JSON Resume Class Theme",
+      "description": "Suspendisse at nulla vitae ligula interdum pretium. Donec.",
+      "url": "https://github.com/jsonresume/jsonresume-theme-class/",
+      "entity": "JSON Resume",
+      "startDate": "2022-07-17",
+      "highlights": [
+        "Nunc imperdiet pharetra eros, sed sodales lectus faucibus.",
+        "Donec mauris lectus, euismod vitae nunc fermentum, dapibus."
+      ]
+    }
+  ],
   "education": [
     {
       "institution": "freeCodeCamp",


### PR DESCRIPTION
Add missing projects section support.

Implements the `projects` section from the JSON Resume schema that was missing from the template. 
Tried to match the existing design as much as possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Projects section to resumes, shown when projects exist. Displays project name (optional external link that opens in a new tab), organization, date range, website, markdown-formatted description, and bullet-list highlights.
* **Style**
  * Added styling for project entity, date, and website elements and extended layout rules to include the new Projects section for consistent spacing and readability.
* **Tests**
  * Added resume fixture data including a sample project to exercise the new section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->