### PR TITLE
chore: add typechecking via typescript

### DIFF
--- a/.github/workflows/pulls.yml
+++ b/.github/workflows/pulls.yml
@@ -9,6 +9,17 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+      - run: yarn install
+      - run: yarn run typecheck
   build:
     runs-on: ubuntu-latest
     steps:

--- a/index.js
+++ b/index.js
@@ -76,11 +76,11 @@ Handlebars.registerHelper("link", (body) => {
 });
 
 /**
- * @param {Object} resume
+ * @param {any} resume
  * @returns {Promise<string>}
  */
 export async function render(resume) {
-  const [ css, template ] = await Promise.all([
+  const loading = Promise.all([
     fs.readFile(import.meta.dirname + "/style.css", "utf-8"),
     fs.readFile(import.meta.dirname + "/resume.handlebars", "utf-8"),
   ]);
@@ -114,6 +114,7 @@ export async function render(resume) {
     }
   }
 
+  const [ css, template ] = await loading;
   const html = Handlebars.compile(template)({
     css,
     resume

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "scripts": {
     "serve": "resume serve --theme . --resume ./test/fixture.resume.json",
+    "typecheck": "tsc --noEmit",
     "build:pdf": "resume export --theme . --resume ./test/fixture.resume.json resume.pdf",
     "build:html": "resume export --theme . --resume ./test/fixture.resume.json resume.html"
   },
@@ -40,6 +41,9 @@
     "marked": "^16.4.1"
   },
   "devDependencies": {
-    "resume-cli": "^3.1.2"
+    "@types/html-minifier": "^4.0.5",
+    "@types/node": "^24.8.1",
+    "resume-cli": "^3.1.2",
+    "typescript": "^5.9.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "preserve",
+    "target": "es2021",
+    "lib": ["es2021"],
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "exclude": [
+    ".yarn/",
+    "node_modules/"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,10 +94,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jsonresume/jsonresume-theme-class@workspace:."
   dependencies:
+    "@types/html-minifier": "npm:^4.0.5"
+    "@types/node": "npm:^24.8.1"
     handlebars: "npm:^4.7.8"
     html-minifier: "npm:^4.0.0"
     marked: "npm:^16.4.1"
     resume-cli: "npm:^3.1.2"
+    typescript: "npm:^5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -153,12 +156,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/clean-css@npm:*":
+  version: 4.2.11
+  resolution: "@types/clean-css@npm:4.2.11"
+  dependencies:
+    "@types/node": "npm:*"
+    source-map: "npm:^0.6.0"
+  checksum: 10c0/bd9848821982500854fed36e672981d9ff286a4cf37b8a7d15a51bbb3f3a3e90676ec18e29e0e753a4c1785c108ca0c30939209cc7dd72712a32fa9d727ea601
+  languageName: node
+  linkType: hard
+
 "@types/cors@npm:^2.8.12":
   version: 2.8.19
   resolution: "@types/cors@npm:2.8.19"
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/b5dd407040db7d8aa1bd36e79e5f3f32292f6b075abc287529e9f48df1a25fda3e3799ba30b4656667ffb931d3b75690c1d6ca71e39f7337ea6dfda8581916d0
+  languageName: node
+  linkType: hard
+
+"@types/html-minifier@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "@types/html-minifier@npm:4.0.5"
+  dependencies:
+    "@types/clean-css": "npm:*"
+    "@types/relateurl": "npm:*"
+    "@types/uglify-js": "npm:*"
+  checksum: 10c0/7ecf8d2358b9f7a88e4c157b1ed951cf9dcf66e1f54f798074082b6d36f88a3eb46b0a364eda8bae5c020b491d7fcab5cd9d6de08021c0337d0156f6f7e12fd4
   languageName: node
   linkType: hard
 
@@ -197,10 +221,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^24.8.1":
+  version: 24.8.1
+  resolution: "@types/node@npm:24.8.1"
+  dependencies:
+    undici-types: "npm:~7.14.0"
+  checksum: 10c0/d185f2f14aa26cc2b482aa730bfc452943f9636df37aad6ceed80aa397f1278f894043336bd72f74c47b3dbef23e772ac9b1a256168984aa8aee26836132d290
+  languageName: node
+  linkType: hard
+
+"@types/relateurl@npm:*":
+  version: 0.2.33
+  resolution: "@types/relateurl@npm:0.2.33"
+  checksum: 10c0/6b6aafe9ed59bf674703555d9fbd3d54c4f27eab3b2abed8faa750ca8b93d883727e111948d3537e6429b43c0990a734525a1aed1baf4c51aebc4f69e3f3fb9f
+  languageName: node
+  linkType: hard
+
 "@types/stack-utils@npm:^1.0.1":
   version: 1.0.1
   resolution: "@types/stack-utils@npm:1.0.1"
   checksum: 10c0/4c4a8c48ba556bbe5fad2232cd9598b7f5f3e110451a3ad5cdf7e42204abf3d1abd30a9e6679d576e8e901e1f6b38e744af1f75f384e697c89bee53e5443b8c9
+  languageName: node
+  linkType: hard
+
+"@types/uglify-js@npm:*":
+  version: 3.17.5
+  resolution: "@types/uglify-js@npm:3.17.5"
+  dependencies:
+    source-map: "npm:^0.6.1"
+  checksum: 10c0/e225d7da26a7a8b71e71f584ab2b4e14f9bd61e2ae4c72fa14d3d862ebfb8f3c1c24414048f23ea485e93618d3370e6c9d5e5af51b6a836d48ec453a26e419f4
   languageName: node
   linkType: hard
 
@@ -4841,6 +4890,26 @@ __metadata:
   version: 0.14.5
   resolution: "tweetnacl@npm:0.14.5"
   checksum: 10c0/4612772653512c7bc19e61923fbf42903f5e0389ec76a4a1f17195859d114671ea4aa3b734c2029ce7e1fa7e5cc8b80580f67b071ecf0b46b5636d030a0102a2
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^5.9.3":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds type checking via TypeScript. As we don't officially maintain a TypeScript interface for JSON Resume, I just use `any` for that. It's a little lazy, but I'll evaluate this later.

Also adds a `test` task to CI, which will enforce types in pull requests. 💪(•ᴗ•💪)

## Chores

* Instead of calling `await` right away when loading files, I load them first, do all other logic, then call await when they're actually needed. This difference is not perceivable, but it is more logical. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated automated type checking into pull request workflows.

* **Chores**
  * Added TypeScript tooling, configuration, and a new type-check script for static validation.

* **Refactor**
  * Improved promise handling in the render flow and updated a JSDoc parameter annotation for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->