### PR TITLE
chore(refactor): start using handlebars partials

### DIFF
--- a/src/_partials/date.handlebars
+++ b/src/_partials/date.handlebars
@@ -1,0 +1,8 @@
+<div class="date">
+  {{#if startDate}}
+  {{{date startDate}}}
+  {{#if (or endDate isEndDateRequired)}}
+  - {{{date endDate}}}
+  {{/if}}
+  {{/if}}
+</div>

--- a/src/_partials/tenure.handlebars
+++ b/src/_partials/tenure.handlebars
@@ -1,0 +1,34 @@
+<div class="item">
+  {{#if name}}
+  <h3>
+    {{name}}
+  </h3>
+  {{/if}}
+
+  <div class="split">
+    {{#if position}}
+    <div class="work_position">
+      {{position}}
+    </div>
+    {{/if}}
+
+    {{> date isEndDateRequired=isEndDateRequired}}
+
+    {{#if url}}
+    <div class="work_website">
+      {{{link url}}}
+    </div>
+    {{/if}}
+  </div>
+
+  {{#if summary}}
+  <p>{{{markdown summary}}}</p>
+  {{/if}}
+  {{#if highlights.length}}
+  <ul>
+    {{#each highlights}}
+    <li>{{{markdown .}}}</li>
+    {{/each}}
+  </ul>
+  {{/if}}
+</div>

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,11 @@
 import fs from 'node:fs/promises';
+import path from 'node:path';
 import Handlebars from 'handlebars';
 import { minify } from 'html-minifier';
 import { marked } from 'marked';
 import { Messages } from './i18n/messages.js';
+
+const PARTIALS_DIR = path.join(import.meta.dirname, '_partials');
 
 /** @type {Intl.DateTimeFormatOptions} */
 const LONG_DATE_FORMAT = { month: 'short', year: 'numeric' };
@@ -63,6 +66,10 @@ Handlebars.registerHelper('link', /** @param {string} body */(body) => {
   const parsed = new URL(body);
   const host = (parsed.host.startsWith('www.')) ? parsed.host.substring(4) : parsed.host;
   return `<a href="${body}">${host}</a>`;
+});
+
+Handlebars.registerHelper('or', (/** @type {unknown} */ a, /** @type {unknown} */ b) => {
+  return a || b;
 });
 
 /**
@@ -205,6 +212,17 @@ export async function render(resume) {
 
     return `<time datetime="${datetime}">${localeString}</time>`;
   });
+
+  for (const p of await fs.readdir(PARTIALS_DIR)) {
+    if (!p.endsWith('.handlebars')) {
+      continue;
+    }
+
+    Handlebars.registerPartial(
+      path.basename(p, '.handlebars'),
+      await fs.readFile(path.join(PARTIALS_DIR, p), 'utf-8')
+    );
+  }
 
   /** @type {Record<string, unknown>} */
   resume.custom = {};

--- a/src/resume.handlebars
+++ b/src/resume.handlebars
@@ -122,46 +122,7 @@
     <section id="work">
       <h2>{{i18n "work-experience"}}</h2>
       {{#each resume.work}}
-      <div class="item">
-        {{#if name}}
-        <h3 class="work_name">
-          {{name}}
-        </h3>
-        {{/if}}
-
-        <div class="split">
-          {{#if position}}
-          <div class="work_position">
-            {{position}}
-          </div>
-          {{/if}}
-
-          <div class="work_date">
-            {{#if startDate}}
-            {{{date startDate}}} - {{{date endDate}}}
-            {{/if}}
-          </div>
-
-          {{#if url}}
-          <div class="work_website">
-            {{{link url}}}
-          </div>
-          {{/if}}
-        </div>
-
-        {{#if summary}}
-        <div class="summary">
-          <p>{{{markdown summary}}}</p>
-        </div>
-        {{/if}}
-        {{#if highlights.length}}
-        <ul class="highlights">
-          {{#each highlights}}
-          <li>{{{markdown .}}}</li>
-          {{/each}}
-        </ul>
-        {{/if}}
-      </div>
+      {{> tenure isEndDateRequired=true}}
       {{/each}}
     </section>
     {{/if}}
@@ -170,51 +131,7 @@
     <section id="volunteer">
       <h2>{{i18n "volunteer"}}</h2>
       {{#each resume.volunteer}}
-      <div class="item">
-        {{#if organization}}
-        <h3 class="company">
-          {{organization}}
-        </h3>
-        {{/if}}
-
-        <div class="split">
-          {{#if position}}
-          <div class="work_position">
-            {{position}}
-          </div>
-          {{/if}}
-
-          <div class="work_date">
-            {{#if startDate}}
-            <span class="startDate">
-              {{{date startDate}}}
-            </span>
-            <span class="endDate">
-              - {{{date endDate}}}
-            </span>
-            {{/if}}
-          </div>
-
-          {{#if url}}
-          <div class="work_website">
-            {{{link url}}}
-          </div>
-          {{/if}}
-        </div>
-
-        {{#if summary}}
-        <div class="summary">
-          <p>{{{markdown summary}}}</p>
-        </div>
-        {{/if}}
-        {{#if highlights.length}}
-        <ul class="highlights">
-          {{#each highlights}}
-          <li>{{{markdown .}}}</li>
-          {{/each}}
-        </ul>
-        {{/if}}
-      </div>
+      {{> tenure name=organization isEndDateRequired=true}}
       {{/each}}
     </section>
     {{/if}}
@@ -241,15 +158,7 @@
             {{entity}}
           </div>
           {{/if}}
-          <div class="project_date">
-            {{#if startDate}}
-            {{#if endDate}}
-            {{{date startDate}}} - {{{date endDate}}}
-            {{else}}
-            {{{date startDate}}}
-            {{/if}}
-            {{/if}}
-          </div>
+          {{> date isEndDateRequired=false}}
         </div>
 
         {{#if description}}
@@ -282,16 +191,7 @@
           </div>
           {{/if}}
 
-          <div class="study_date">
-            {{#if startDate}}
-            <span class="startDate">
-              {{{date startDate}}}
-            </span>
-            <span class="endDate">
-              - {{{date endDate}}}
-            </span>
-            {{/if}}
-          </div>
+          {{> date isEndDateRequired=true}}
 
           {{#if url}}
           <div class="work_website">
@@ -335,12 +235,10 @@
         </div>
         {{/if}}
         {{#if level}}
-        <div class="level">
-          <em>{{level}}</em>
-        </div>
+        <em>{{level}}</em>
         {{/if}}
         {{#if keywords.length}}
-        <ul class="keywords">
+        <ul>
           {{#each keywords}}
           <li>{{.}}</li>
           {{/each}}
@@ -397,7 +295,7 @@
       {{#each resume.references}}
       <div class="item">
         {{#if reference}}
-        <blockquote class="reference">
+        <blockquote>
           {{reference}}
         </blockquote>
         {{/if}}

--- a/src/style.css
+++ b/src/style.css
@@ -85,13 +85,6 @@ header h2 {
   margin-right: 2em;
 }
 
-.project_entity,
-.project_date,
-.project_website {
-  margin-bottom: 10px;
-  width: 30%;
-}
-
 .website,
 .email,
 .phone,
@@ -106,12 +99,12 @@ header h2 {
   margin-top: .5em;
 }
 
-.work_date,
+.date,
 .work_position,
 .work_website,
 .institution,
-.study_date,
-.qualification {
+.qualification,
+.project_entity {
   margin-bottom: 10px;
   width: 30%;
 }


### PR DESCRIPTION
See commit message.

---

In theory, this should change nothing for end users. At most, just some of the underlying HTML elements and CSS classes assigned. But the exported CV will visually look identical.

The output HTML is a bit leaner too which is nice, the fixture in the repository goes from 6.5 kB to 6.2 kB. 💪(•ᴗ•💪)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Resume template restructured to use modular components for rendering work experience, volunteer roles, education, and project information, improving consistency across sections.

* **Style**
  * Updated CSS styling and layout for resume sections and profile area displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->